### PR TITLE
Wordchar patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+coverage
+rdoc
+pkg
+Gemfile.lock
+.idea/*
+.rvmrc
+.bundle
+*.gem
+*.patch

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/htmldiff.gemspec
+++ b/htmldiff.gemspec
@@ -3,8 +3,8 @@ Gem::Specification.new do |s|
   s.version = '1.0.0'
   s.authors = ['Nathan Herald']
   s.email = %q{nathan@myobie.com}
-  s.description = %q{HTML diffs of text (borrowed from a wiki software I no longer remember)}
-  s.summary = %q{HTML diffs of text (borrowed from a wiki software I no longer remember)}
+  s.description = %q{HTML diffs of text}
+  s.summary = %q{HTML diffs of text}
   s.homepage = %q{http://github.com/myobie/htmldiff}
   s.license = 'MIT'
   

--- a/htmldiff.gemspec
+++ b/htmldiff.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name = %q{htmldiff}
   s.version = '1.0.0'
@@ -7,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary = %q{HTML diffs of text}
   s.homepage = %q{http://github.com/myobie/htmldiff}
   s.license = 'MIT'
-  
+
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'rake', '~> 12.1'
 

--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -1,22 +1,27 @@
+# frozen_string_literal: true
+
 module HTMLDiff
 
   Match = Struct.new(:start_in_old, :start_in_new, :size)
+
   class Match
     def end_in_old
       self.start_in_old + self.size
     end
-    
+
     def end_in_new
       self.start_in_new + self.size
     end
   end
-  
+
   Operation = Struct.new(:action, :start_in_old, :end_in_old, :start_in_new, :end_in_new)
 
   class DiffBuilder
+    WORDCHAR_REGEXP = /[\p{Latin}\p{Greek}\p{Cyrillic}\d@#.]/i
 
     def initialize(old_version, new_version)
-      @old_version, @new_version = old_version, new_version
+      @old_version = old_version
+      @new_version = new_version
       @content = []
     end
 
@@ -24,7 +29,7 @@ module HTMLDiff
       split_inputs_to_words
       index_new_words
       operations.each { |op| perform_operation(op) }
-      return @content.join
+      @content.join
     end
 
     def split_inputs_to_words
@@ -40,16 +45,17 @@ module HTMLDiff
     def operations
       position_in_old = position_in_new = 0
       operations = []
-      
+
       matches = matching_blocks
-      # an empty match at the end forces the loop below to handle the unmatched tails
-      # I'm sure it can be done more gracefully, but not at 23:52
+
+      # An empty match at the end forces the loop below to handle the unmatched tails
+      # TODO: Refactor to handle more gracefully
       matches << Match.new(@old_words.length, @new_words.length, 0)
-      
-      matches.each_with_index do |match, i|
+
+      matches.each do |match|
         match_starts_at_current_position_in_old = (position_in_old == match.start_in_old)
         match_starts_at_current_position_in_new = (position_in_new == match.start_in_new)
-        
+
         action_upto_match_positions = 
           case [match_starts_at_current_position_in_old, match_starts_at_current_position_in_new]
           when [false, false]
@@ -64,23 +70,23 @@ module HTMLDiff
           end
 
         if action_upto_match_positions != :none
-          operation_upto_match_positions = 
-              Operation.new(action_upto_match_positions, 
-                  position_in_old, match.start_in_old, 
-                  position_in_new, match.start_in_new)
+          operation_upto_match_positions = Operation.new(action_upto_match_positions,
+                                                         position_in_old, match.start_in_old,
+                                                         position_in_new, match.start_in_new)
           operations << operation_upto_match_positions
         end
-        if match.size != 0
-          match_operation = Operation.new(:equal, 
-              match.start_in_old, match.end_in_old, 
-              match.start_in_new, match.end_in_new)
+
+        unless match.size == 0
+          match_operation = Operation.new(:equal,
+                                          match.start_in_old, match.end_in_old,
+                                          match.start_in_new, match.end_in_new)
           operations << match_operation
         end
 
         position_in_old = match.end_in_old
         position_in_new = match.end_in_new
       end
-      
+
       operations
     end
 
@@ -92,29 +98,32 @@ module HTMLDiff
 
     def recursively_find_matching_blocks(start_in_old, end_in_old, start_in_new, end_in_new, matching_blocks)
       match = find_match(start_in_old, end_in_old, start_in_new, end_in_new)
-      if match
-        if start_in_old < match.start_in_old and start_in_new < match.start_in_new
-          recursively_find_matching_blocks(
-              start_in_old, match.start_in_old, start_in_new, match.start_in_new, matching_blocks) 
-        end
-        matching_blocks << match
-        if match.end_in_old < end_in_old and match.end_in_new < end_in_new
-          recursively_find_matching_blocks(
-              match.end_in_old, end_in_old, match.end_in_new, end_in_new, matching_blocks)
-        end
+      return unless match
+
+      if start_in_old < match.start_in_old and start_in_new < match.start_in_new
+        recursively_find_matching_blocks(start_in_old,
+                                         match.start_in_old,
+                                         start_in_new,
+                                         match.start_in_new,
+                                         matching_blocks)
+      end
+      matching_blocks << match
+      if match.end_in_old < end_in_old and match.end_in_new < end_in_new
+        recursively_find_matching_blocks(match.end_in_old,
+                                         end_in_old,
+                                         match.end_in_new,
+                                         end_in_new,
+                                         matching_blocks)
       end
     end
 
     def find_match(start_in_old, end_in_old, start_in_new, end_in_new)
-
       best_match_in_old = start_in_old
       best_match_in_new = start_in_new
       best_match_size = 0
-      
       match_length_at = Hash.new { |h, index| h[index] = 0 }
-      
-      start_in_old.upto(end_in_old - 1) do |index_in_old|
 
+      start_in_old.upto(end_in_old - 1) do |index_in_old|
         new_match_length_at = Hash.new { |h, index| h[index] = 0 }
 
         @word_indices[@old_words[index_in_old]].each do |index_in_new|
@@ -133,12 +142,9 @@ module HTMLDiff
         match_length_at = new_match_length_at
       end
 
-#      best_match_in_old, best_match_in_new, best_match_size = add_matching_words_left(
-#          best_match_in_old, best_match_in_new, best_match_size, start_in_old, start_in_new)
-#      best_match_in_old, best_match_in_new, match_size = add_matching_words_right(
-#          best_match_in_old, best_match_in_new, best_match_size, end_in_old, end_in_new)
+      return if best_match_size == 0
 
-      return (best_match_size != 0 ? Match.new(best_match_in_old, best_match_in_new, best_match_size) : nil)
+      Match.new(best_match_in_old, best_match_in_new, best_match_size)
     end
 
     def add_matching_words_left(match_in_old, match_in_new, match_size, start_in_old, start_in_new)
@@ -160,8 +166,8 @@ module HTMLDiff
       end
       [match_in_old, match_in_new, match_size]
     end
-    
-    VALID_METHODS = [:replace, :insert, :delete, :equal]
+
+    VALID_METHODS = %i[replace insert delete equal].freeze
 
     def perform_operation(operation)
       @operation = operation
@@ -172,20 +178,20 @@ module HTMLDiff
       delete(operation, 'diffmod')
       insert(operation, 'diffmod')
     end
-    
+
     def insert(operation, tagclass = 'diffins')
       insert_tag('ins', tagclass, @new_words[operation.start_in_new...operation.end_in_new])
     end
-    
+
     def delete(operation, tagclass = 'diffdel')
-       insert_tag('del', tagclass, @old_words[operation.start_in_old...operation.end_in_old])
+      insert_tag('del', tagclass, @old_words[operation.start_in_old...operation.end_in_old])
     end
-    
+
     def equal(operation)
       # no tags to insert, simply copy the matching words from one of the versions
       @content += @new_words[operation.start_in_new...operation.end_in_new]
     end
-  
+
     def opening_tag?(item)
       item =~ %r!^\s*<[^>]+>\s*$!
     end
@@ -197,7 +203,7 @@ module HTMLDiff
     def tag?(item)
       opening_tag?(item) or closing_tag?(item)
     end
-    
+
     def img_tag?(item)
       (item[0..4].downcase == '<img ') && (item[-2..-1].downcase == '/>')
     end
@@ -246,41 +252,41 @@ module HTMLDiff
     end
 
     def explode(sequence)
-      sequence.is_a?(String) ? sequence.split("") : sequence
+      sequence.is_a?(String) ? sequence.split('') : sequence
     end
-  
+
     def end_of_tag?(char)
       char == '>'
     end
-  
+
     def start_of_tag?(char)
       char == '<'
     end
 
     def wordchar?(char)
-      char =~ /[\p{Alnum}@#.]/i
+      char.match?(WORDCHAR_REGEXP)
     end
 
     def convert_html_to_list_of_words(x, use_brackets = false)
       mode = :wordchar
-      current_word  = ''
+      current_word  = +''
       words = []
 
       explode(x).each do |char|
         case mode
         when :tag
-          if end_of_tag? char
+          if end_of_tag?(char)
             current_word << (use_brackets ? ']' : '>')
             words << current_word
-            current_word = ''
+            current_word = +''
             mode = :wordchar
           else
             current_word << char
           end
         when :wordchar
-          if start_of_tag? char
+          if start_of_tag?(char)
             words << current_word unless current_word.empty?
-            current_word = (use_brackets ? '[' : '<')
+            current_word = use_brackets ? +'[' : +'<'
             mode = :tag
           elsif wordchar?(char)
             current_word << char
@@ -290,12 +296,11 @@ module HTMLDiff
             mode = :other
           end
         when :other
-          if start_of_tag? char
-            words << current_word unless current_word.empty?
-            current_word = (use_brackets ? '[' : '<')
+          words << current_word unless current_word.empty?
+          if start_of_tag?(char)
+            current_word = use_brackets ? +'[' : +'<'
             mode = :tag
           else
-            words << current_word unless current_word.empty?
             current_word = char
             mode = :wordchar if wordchar?(char)
           end
@@ -306,11 +311,9 @@ module HTMLDiff
       words << current_word unless current_word.empty?
       words
     end
+  end
 
-  end # of class Diff Builder
-  
   def diff(a, b)
     DiffBuilder.new(a, b).build
   end
-
 end

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -7,37 +7,110 @@ class TestDiff
 end
 
 describe "htmldiff" do
-  
+
   it "should diff text" do
-    
     diff = TestDiff.diff('a word is here', 'a nother word is there')
     diff.should == "a<ins class=\"diffins\"> nother</ins> word is <del class=\"diffmod\">here</del><ins class=\"diffmod\">there</ins>"
-    
   end
-  
+
   it "should insert a letter and a space" do
     diff = TestDiff.diff('a c', 'a b c')
     diff.should == "a <ins class=\"diffins\">b </ins>c"
   end
-  
+
   it "should remove a letter and a space" do
     diff = TestDiff.diff('a b c', 'a c')
     diff.should == "a <del class=\"diffdel\">b </del>c"
   end
-  
+
   it "should change a letter" do
     diff = TestDiff.diff('a b c', 'a d c')
     diff.should == "a <del class=\"diffmod\">b</del><ins class=\"diffmod\">d</ins> c"
   end
 
-  it "should support Chinese" do
-    diff = TestDiff.diff('这个是中文内容, Ruby is the bast', '这是中国语内容，Ruby is the best language.')
-    diff.should == "<del class=\"diffmod\">这个是中文内容, </del><ins class=\"diffmod\">这是中国语内容，</ins>Ruby is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>"
-  end
-
   it "should support accents" do
     diff = TestDiff.diff('blåbær dèjá vu', 'blåbær deja vu')
     diff.should == "blåbær <del class=\"diffmod\">dèjá</del><ins class=\"diffmod\">deja</ins> vu"
+  end
+
+  it "should support Chinese" do
+    diff = TestDiff.diff('这个是中文内容, Ruby is the bast', '这是中国语内容，Ruby is the best language.')
+    diff.should == "这<del class=\"diffdel\">个</del>是中<del class=\"diffmod\">文</del><ins class=\"diffmod\">国语</ins>内容<del class=\"diffmod\">, </del><ins class=\"diffmod\">，</ins>Ruby is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>"
+  end
+
+  it "should support Cyrillic" do
+    diff = TestDiff.diff('Привет, как дела?', 'Привет, хорошо дела!')
+    diff.should == "Привет, <del class=\"diffmod\">как</del><ins class=\"diffmod\">хорошо</ins> дела<del class=\"diffmod\">?</del><ins class=\"diffmod\">!</ins>"
+  end
+
+  it "should support Greek" do
+    diff = TestDiff.diff('Καλημέρα κόσμε', 'Καλησπέρα κόσμε')
+    diff.should == "<del class=\"diffmod\">Καλημέρα</del><ins class=\"diffmod\">Καλησπέρα</ins> κόσμε"
+  end
+
+  pending "should support Arabic" do
+    diff = TestDiff.diff('مرحبا بالعالم', 'مرحبا جميل بالعالم')
+    diff.should == "مرحبا <ins class=\"diffins\">جميل </ins>بالعالم"
+  end
+
+  it "should support Hebrew" do
+    diff = TestDiff.diff('שלום עולם', 'שלום עולם קטן')
+    diff.should == "שלום עולם<ins class=\"diffins\"> קטן</ins>"
+  end
+
+  it "should support Vietnamese" do
+    diff = TestDiff.diff('Xin chào thế giới', 'Xin chào thế giới mới')
+    diff.should == "Xin chào thế giới<ins class=\"diffins\"> mới</ins>"
+  end
+
+  it "should handle mixed scripts" do
+    diff = TestDiff.diff('Hello مرحبا Привет', 'Hello مرحبا جدا Привет')
+    diff.should == "Hello مرحبا <ins class=\"diffins\">جدا </ins>Привет"
+  end
+
+  it "should support Cyrillic with HTML tags" do
+    diff = TestDiff.diff('<div>Текст в теге</div>', '<div>Новый текст в теге</div>')
+    diff.should == "<div><del class=\"diffmod\">Текст</del><ins class=\"diffmod\">Новый текст</ins> в теге</div>"
+  end
+
+  pending "should support Arabic with HTML tags" do
+    diff = TestDiff.diff('<span>النص في العلامة</span>', '<span>النص الجديد في العلامة</span>')
+    diff.should == "<span>النص <ins class=\"diffins\">الجديد </ins>في العلامة</span>"
+  end
+
+  pending "should handle complex Hebrew changes" do
+    diff = TestDiff.diff('אני אוהב לתכנת בשפת רובי', 'אני אוהב מאוד לתכנת בשפת פייתון')
+    diff.should == "אני אוהב <ins class=\"diffins\">מאוד </ins>לתכנת בשפת <del class=\"diffmod\">רובי</del><ins class=\"diffmod\">פייתון</ins>"
+  end
+
+  it "should support Vietnamese diacritics" do
+    diff = TestDiff.diff('Tôi yêu lập trình', 'Tôi thích lập trình')
+    diff.should == "Tôi <del class=\"diffmod\">yêu</del><ins class=\"diffmod\">thích</ins> lập trình"
+  end
+
+  it "should handle mixed languages with punctuation" do
+    diff = TestDiff.diff('Hello, Привет! مرحبا. שלום', 'Hello, Привет! مرحبا جدا. שלום עולם')
+    diff.should == "Hello, Привет! مرحبا<ins class=\"diffins\"> جدا</ins>. שלום<ins class=\"diffins\"> עולם</ins>"
+  end
+
+  it "should support Greek with formatting tags" do
+    diff = TestDiff.diff('<b>Γεια σας</b> κόσμε', '<b>Γεια σου</b> κόσμε')
+    diff.should == "<b>Γεια <del class=\"diffmod\">σας</del><ins class=\"diffmod\">σου</ins></b> κόσμε"
+  end
+
+  pending "should detect changes within Arabic words" do
+    diff = TestDiff.diff('البرمجة ممتعة', 'البرمجة سهلة')
+    diff.should == "البرمجة <del class=\"diffmod\">ممتعة</del><ins class=\"diffmod\">سهلة</ins>"
+  end
+
+  it "should properly handle RTL text with HTML" do
+    diff = TestDiff.diff('<div dir="rtl">שלום עולם</div>', '<div dir="rtl">שלום חבר</div>')
+    diff.should == "<div dir=\"rtl\">שלום <del class=\"diffmod\">עולם</del><ins class=\"diffmod\">חבר</ins></div>"
+  end
+
+  it "should handle multi-word changes in Vietnamese" do
+    diff = TestDiff.diff('Tôi đang học Ruby', 'Tôi đang học Python rất vui')
+    diff.should == "Tôi đang học <del class=\"diffmod\">Ruby</del><ins class=\"diffmod\">Python rất vui</ins>"
   end
 
   it "should support email addresses" do
@@ -64,12 +137,11 @@ describe "htmldiff" do
     diff = TestDiff.diff(oldv, newv)
     diff.should == "a b <ins class=\"diffins\"><img src=\"some_url\" /> </ins>c"
   end
-  
+
   it "should support img tags deletion" do
     oldv = 'a b c'
     newv = 'a b <img src="some_url" /> c'
     diff = TestDiff.diff(newv, oldv)
     diff.should == "a b <del class=\"diffdel\"><img src=\"some_url\" /> </del>c"
   end
-  
 end


### PR DESCRIPTION
@myobie here are the promised updates to Htmldiff.

The main change is to tweak the diff engine to properly support "wordchars", defined as:
- alphabet-like letters (Latin, Cyrillic, Greek)
- accents
- email addresses and single words
- escaped HTML including `&lt;` and `&gt;` (not really working yet)

More info: Previously the statemachine has 4 states, :tag, :char, :whitespace, and indeterminant (which meant continue with the previous state), as certain chars where neither :char nor :whitesapce. I removed the indeterminant case so now a char is either a :wordchar (in which case join to the word being parsed) or an :other in which case go to the next word.

I will do some additional improvement on this when bandwidth allows; it simply requires having a large amount of test cases and fixing them all.