### PR TITLE
fix gem build htmldiff.gemspec

### DIFF
--- a/htmldiff.gemspec
+++ b/htmldiff.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'diff-lcs'
 
-  spec.files = Dir.glob('lib/**/*') + %w[LICENSE README]
+  spec.files = Dir.glob('lib/**/*') + %w[LICENSE README.md]
   spec.require_paths = ['lib']
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
README.md file not found fix